### PR TITLE
fix: next.config の favicon.ico 正規表現エスケープ

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -8,7 +8,7 @@ const nextConfig: NextConfig = {
         // 静的アセット(_next/static, _next/image, favicon.ico)は除外する。
         // これらは Next.js が immutable な長期キャッシュを付与するため、
         // s-maxage=60 の CDN-Cache-Control で上書きしない。
-        source: '/((?!_next/static|_next/image|favicon.ico).*)',
+        source: '/((?!_next/static|_next/image|favicon\\.ico).*)',
         headers: [
           {
             key: 'CDN-Cache-Control',


### PR DESCRIPTION
## 概要

PR #20（パッケージアップグレード）のフォローアップ。レビューで確定した軽微指摘 [5] を修正。

`next.config.ts` の `headers()` の `source` にある negative lookahead で、`favicon.ico` の `.` がエスケープされておらず任意文字にマッチしていた。`faviconXico` のような別パスまで CDN-Cache-Control の付与対象から過剰に除外していた。

## 修正

```diff
- source: '/((?!_next/static|_next/image|favicon.ico).*)',
+ source: '/((?!_next/static|_next/image|favicon\.ico).*)',
```

## 影響

実在パスへの挙動は不変：
- `/favicon.ico` → 引き続き除外（正）
- `/`・`/articles/*`・`/ogp.jpg` 等 → 従来通りヘッダ付与
- `/faviconXico`（仮想の別パス）→ 過剰除外が解消されヘッダ付与されるように

## 検証

Next.js の `path-to-regexp` で全ケース実測、`npm run build` / `eslint .` ともに成功。

🤖 Generated with [Claude Code](https://claude.com/claude-code)