### PR TITLE
chore: Renovate と CI (lint + tsc) を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  check:
+    name: lint & typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: Lint (ESLint)
+        run: npm run lint
+      - name: Type check (tsc)
+        run: npx tsc --noEmit

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", ":dependencyDashboard", ":semanticCommits"],
+  "timezone": "Asia/Tokyo",
+  "schedule": ["before 9am on monday"],
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "description": "patch / minor はまとめて 1 PR にし、CI 通過後に自動マージ",
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "non-major dependencies",
+      "automerge": true
+    },
+    {
+      "description": "major は個別 PR・手動レビュー（破壊的変更を伴うため自動マージしない）",
+      "matchUpdateTypes": ["major"],
+      "automerge": false,
+      "addLabels": ["major"]
+    }
+  ],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "automerge": true
+  }
+}


### PR DESCRIPTION
## 概要

依存パッケージの追従を自動化し、PR を検証する CI を整備します。

## 追加内容

### `renovate.json`
- **patch / minor**: グループ化して 1 PR にまとめ、CI 通過後に**自動マージ**
- **major**: 個別 PR・**手動レビュー**（破壊的変更を伴うため自動マージしない / `major` ラベル付与）
- `lockFileMaintenance` 有効化、Dependency Dashboard 作成
- スケジュール: 毎週月曜 9時(JST)前にまとめて実行（ノイズ低減）

### `.github/workflows/ci.yml`
- `pull_request` と main への `push` で **`eslint .` + `tsc --noEmit`** を実行
- Node 22（`engines: >=22.x` に整合）
- **`build` は Vercel に委譲**: build は microCMS の API キーを要するため、Actions では Vercel がカバーしない lint + tsc を担当（Actions=lint+tsc / Vercel=build で 3 種を分担）

## マージ後に必要な手動設定

1. **Renovate GitHub App をインストール**: https://github.com/apps/renovate （対象 repo を許可）
2. 自動マージを使うなら repo Settings → **「Allow auto-merge」を ON**
3. （任意）Branch protection で `CI / lint & typecheck` を必須チェックに設定するとより安全

🤖 Generated with [Claude Code](https://claude.com/claude-code)